### PR TITLE
Fix long username display

### DIFF
--- a/_neayiHeaderFooter.scss
+++ b/_neayiHeaderFooter.scss
@@ -167,6 +167,7 @@
             color         : white !important;
             text-transform: none;
             letter-spacing: normal;
+            white-space   : normal;
         }
     }
 }


### PR DESCRIPTION
Allow white space line wrap instead of bad display under the avatar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the display of profile usernames to allow text to wrap naturally for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->